### PR TITLE
Refactor: use environment variables & config export for different domains

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -9,6 +9,8 @@
   </NuxtLayout>
 </template>
 
-<!-- <script lang="ts" setup>
-defineRobotMeta()
-</script> -->
+<script setup>
+//defineRobotMeta()
+const  {locale}  = useI18n();
+console.log(locale);
+</script> 

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -5,4 +5,5 @@ module.exports = {
     au: process.env.DOMAIN_AU,
     us: process.env.DOMAIN_US,
     pl: process.env.DOMAIN_PL,
+    test: process.env.DOMAIN_TEST,
   };

--- a/config/locale-domains.js
+++ b/config/locale-domains.js
@@ -1,0 +1,8 @@
+module.exports = {
+    uk: process.env.DOMAIN_UK,
+    sg: process.env.DOMAIN_SG,
+    ie: process.env.DOMAIN_IE,
+    au: process.env.DOMAIN_AU,
+    us: process.env.DOMAIN_US,
+    pl: process.env.DOMAIN_PL,
+  };

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -78,7 +78,7 @@ export default defineNuxtConfig({
             {
                 code: 'en-pl',
                 name: 'PL',
-                domain: "https://evercam-static.vercel.app/",
+                domain: localeDomains.test,
             },
 
         ],

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
+const localeDomains = require('./config/locale-domains')
+
 export default defineNuxtConfig({
     modules: [
         ['@storyblok/nuxt', { accessToken: process.env.STORYBLOK_API_KEY }],
@@ -46,33 +48,37 @@ export default defineNuxtConfig({
             {
                 code: 'en-sg',
                 name: 'SG',
-                domain: "https://evercam.sg/",
-
+                domain: localeDomains.sg,
             },
             {
                 code: 'en-ie',
                 name: 'IE',
-                domain: "https://evercam.io/",
+                domain: localeDomains.ie,
             },
             {
                 code: 'en-uk',
                 name: 'UK',
-                domain: "https://evercam.uk/",
+                domain: localeDomains.uk,
             },
             {
                 code: 'en-au',
                 name: 'AU',
-                domain: "https://evercam.com.au/",
+                domain: localeDomains.au,
             },
             {
                 code: 'en-us',
                 name: 'US',
-                domain: "https://evercam.com/",
+                domain: localeDomains.us,
             },
             {
                 code: 'en-pl',
                 name: 'PL',
-                domain: "https://evercam.pl/",
+                domain: localeDomains.pl,
+            },
+            {
+                code: 'en-pl',
+                name: 'PL',
+                domain: "https://evercam-static.vercel.app/",
             },
 
         ],
@@ -91,7 +97,7 @@ export default defineNuxtConfig({
     ],
     runtimeConfig: {
         public: {
-            siteUrl: process.env.NUXT_PUBLIC_SITE_URL || 'https://www.evercam.sg',
+            siteUrl: localeDomains.sg,
             siteName: 'Construction Time-lapse & Project Management Live Cameras | Evercam',
             siteDescription: 'Construction time-lapse cameras & project management software helps in marketing content, project management and dispute avoidance in the construction industry.',
             language: 'en-SG', // prefer more explicit language codes like `en-AU` over `en`


### PR DESCRIPTION
Needed change on local `.env` : 

```
DOMAIN_SG=https://evercam.sg/
DOMAIN_IE=https://evercam.io/
DOMAIN_US=https://evercam.com/
DOMAIN_UK=https://evercam.uk/
DOMAIN_AU=https://evercam.com.au/
DOMAIN_PL=https://evercam.pl/
```